### PR TITLE
【課題31】生徒情報のキャンセルチェックボックスの実装

### DIFF
--- a/src/main/java/raisetech/student_management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student_management/repository/StudentRepository.java
@@ -37,7 +37,7 @@ public interface StudentRepository {
   void registerNewStudentCourse(StudentsCourses studentsCourses);
 
   @Update("UPDATE students SET full_name = #{fullName}, furigana = #{furigana}, handle_name = #{handleName}, "
-      + "mail_address = #{mailAddress}, area = #{area}, age = #{age}, gender = #{gender}, remark =  #{remark}, isDeleted = #{isDeleted} WHERE id = #{id}")
+      + "mail_address = #{mailAddress}, area = #{area}, age = #{age}, gender = #{gender}, remark =  #{remark}, is_deleted = #{isDeleted} WHERE id = #{id}")
   void updateStudent(Student student);
 
   @Update("UPDATE students_courses SET course_name = #{courseName} WHERE course_id = #{courseId}" )

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -17,6 +17,7 @@
     <th>年齢</th>
     <th>性別</th>
     <th>備考</th>
+    <th>キャンセル</th>
   </tr>
   </thead>
   <tbody>
@@ -32,6 +33,9 @@
     <td th:text="${studentDetail.student.age}">29</td>
     <td th:text="${studentDetail.student.gender}">男性</td>
     <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td >
+      <input type="checkbox" th:checked="${studentDetail.student.isDeleted}">
+    </td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -13,7 +13,7 @@
     <input type="text" id="courseName" th:id="studentsCourses.__${stat.index}__.courseName" th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
   </div>
   <div>
-    <label for="fullName">ID:</label>
+    <label for="id">ID:</label>
     <input type="text" id="id" th:field="*{student.id}" required>
   </div>
   <div>
@@ -48,7 +48,10 @@
     <label for="remark">備考:</label>
     <input type="text" id="remark" th:field="*{student.remark}" >
   </div>
-
+  <div>
+    <label for="isDeleted">キャンセル:</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}" >
+  </div>
   <div>
     <button type="submit">更新</button>
   </div>


### PR DESCRIPTION
### 実装の概要
生徒のキャンセルを更新、確認をするチェックボックスを実装しました

### 変更理由
一覧にいる生徒が現在も受講中なのか、キャンセルした生徒なのか、現状UI上からは判断できなかったため

### やったこと
・生徒一覧上にキャンセル有無のチェックボックスの実装
・更新画面からキャンセルの変更が可能

### やらないこと
・コードのリファクタリング

### 動作確認
更新画面
<img width="847" height="676" alt="image" src="https://github.com/user-attachments/assets/3820ba5d-8782-4785-a89e-baa2ba2b3f0f" />

一覧画面（キャンセル前）
<img width="1229" height="459" alt="image" src="https://github.com/user-attachments/assets/6c8a6aa0-4f56-4257-9261-6f2b943a8d46" />

一覧画面（キャンセル後）
<img width="1272" height="436" alt="image" src="https://github.com/user-attachments/assets/6cfbd355-1993-423a-beec-e53bdf41da75" />

### 使い方
生徒情報一覧から、キャンセルしたい生徒の名前を押下。
更新画面に切り替わるので、キャンセルのチェックボックスを押下。
画面下にある更新ボタンを押下。

### 課題
DataではstudentクラスのisDeletedと定義しているが、thymeleafが上手く反応せず、deletedとしているところがある。今後リファクタリングするか要検討。

### 工夫したとこと
今回からローカルとリモートのブランチを毎回マージした後に削除して、新規作成して変更をするようにしました。（branchの名前も今まではtestしか使っていませんでしたが、何をするbranchなのか一目で分かるように名前を考えてつけてみました。）より実務に近い形で出来たらと思い変更したので、今後も続けていきます。
今回の実装は自力でやりきろうと取り組みましたが、結局手も足も出ず講義をみてしまいました。すごく悔しかったので自力で１からやり直します。

