### PR TITLE
【課題41】JUnitを使ったcontrollerのテスト実装

### DIFF
--- a/src/main/java/raisetech/student_management/controller/StudentController.java
+++ b/src/main/java/raisetech/student_management/controller/StudentController.java
@@ -48,7 +48,7 @@ public class StudentController {
    * @return　受講生詳細一覧（全体）
    */
   @Operation(summary = "一覧検索", description = "受講生の一覧を検索します")
-  @GetMapping("/studentsList")
+  @GetMapping("/studentList")
   public List<StudentDetail> getStudentList() {
     return service.searchStudentList();
   }

--- a/src/main/java/raisetech/student_management/data/Student.java
+++ b/src/main/java/raisetech/student_management/data/Student.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,6 +13,7 @@ import lombok.Setter;
 @Setter
 public class Student {
 
+  @Pattern(regexp= "^\\d+$", message = "数字のみ入力するようにしてください。")
   private String id;
 
 

--- a/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
@@ -16,8 +16,11 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+
+
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import raisetech.student_management.data.Student;
@@ -34,7 +37,7 @@ class StudentControllerTest {
   @Autowired
   private ObjectMapper objectMapper;
 
-  @MockitoBean
+  @MockBean
   private StudentService service;
 
   private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
@@ -126,7 +129,7 @@ class StudentControllerTest {
 
     assertThat(violations.size()).isEqualTo(1);
     assertThat(violations).extracting("message")
-        .containsOnly("数字のみ入力するようにしてください");
+        .containsOnly("数字のみ入力するようにしてください。");
 
   }
 

--- a/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
@@ -44,7 +44,7 @@ class StudentControllerTest {
   }
 
   @Test
-  void 受講生詳細の受講生で適切な値を入力した時に入力チェックに以上が発生しないこと() {
+  void 受講生詳細の受講生で適切な値を入力した時に入力チェックに異常が発生しないこと() {
     Student student = new Student();
     student.setId("1");
     student.setFullName("田中　太郎");
@@ -73,7 +73,7 @@ class StudentControllerTest {
 
     assertThat(violations.size()).isEqualTo(1);
     assertThat(violations).extracting("message")
-        .containsOnly("数字のみ入力するようにしてください。");
+        .containsOnly("数字のみ入力するようにしてください");
 
   }
 }

--- a/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
@@ -2,13 +2,12 @@ package raisetech.student_management.controller;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -17,10 +16,12 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import raisetech.student_management.data.Student;
+import raisetech.student_management.data.StudentCourse;
 import raisetech.student_management.domain.StudentDetail;
 import raisetech.student_management.service.StudentService;
 
@@ -29,6 +30,9 @@ class StudentControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
 
   @MockitoBean
   private StudentService service;
@@ -41,6 +45,55 @@ class StudentControllerTest {
         .andExpect(status().isOk());
 
     verify(service, times(1)).searchStudentList();
+  }
+
+  @Test
+  void 受講生詳細の登録が実行できること() throws Exception {
+    Student student = new Student();
+    StudentCourse studentCourse = new StudentCourse();
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    student.setId("1");
+    student.setFullName("田中　太郎");
+    student.setFurigana("タナカタロウ");
+    student.setHandleName("タロー");
+    student.setMailAddress("taro@example.com");
+    student.setArea("東京");
+    student.setAge(30);
+    student.setGender("男性");
+    studentCourse.setCourseName("国語");
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/registerStudent")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).registerNewStudent(any(StudentDetail.class));
+
+  }
+
+  @Test
+  void 受講生の更新が実行できること() throws Exception{
+    Student student = new Student();
+    StudentCourse studentCourse = new StudentCourse();
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+    student.setId("1");
+    student.setFullName("田中　太郎");
+    student.setFurigana("タナカタロウ");
+    student.setHandleName("タロー");
+    student.setMailAddress("taro@example.com");
+    student.setArea("東京");
+    student.setAge(30);
+    student.setGender("男性");
+    studentCourse.setCourseName("国語");
+
+    mockMvc.perform(MockMvcRequestBuilders.put("/updateStudent")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(studentDetail)))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).updateStudent(any(StudentDetail.class));
   }
 
   @Test
@@ -76,4 +129,6 @@ class StudentControllerTest {
         .containsOnly("数字のみ入力するようにしてください");
 
   }
+
+
 }

--- a/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
+++ b/src/test/java/raisetech/student_management/controller/StudentControllerTest.java
@@ -1,0 +1,79 @@
+package raisetech.student_management.controller;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import raisetech.student_management.data.Student;
+import raisetech.student_management.domain.StudentDetail;
+import raisetech.student_management.service.StudentService;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private StudentService service;
+
+  private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+  @Test
+  void 受講生詳細の一覧検索が実行できて空のリストが返ってくること() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/studentList"))
+        .andExpect(status().isOk());
+
+    verify(service, times(1)).searchStudentList();
+  }
+
+  @Test
+  void 受講生詳細の受講生で適切な値を入力した時に入力チェックに以上が発生しないこと() {
+    Student student = new Student();
+    student.setId("1");
+    student.setFullName("田中　太郎");
+    student.setFurigana("タナカタロウ");
+    student.setHandleName("タロー");
+    student.setMailAddress("taro@example.com");
+    student.setArea("東京");
+    student.setGender("男性");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(0);
+  }
+  @Test
+  void 受講生詳細の受講生でIDに数字以外を用いた時に入力チェックに掛かること(){
+    Student student = new Student();
+    student.setId("テストです。");
+    student.setFullName("田中　太郎");
+    student.setFurigana("タナカタロウ");
+    student.setHandleName("タロー");
+    student.setMailAddress("taro@example.com");
+    student.setArea("東京");
+    student.setGender("男性");
+
+    Set<ConstraintViolation<Student>> violations = validator.validate(student);
+
+    assertThat(violations.size()).isEqualTo(1);
+    assertThat(violations).extracting("message")
+        .containsOnly("数字のみ入力するようにしてください。");
+
+  }
+}

--- a/src/test/java/raisetech/student_management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student_management/service/StudentServiceTest.java
@@ -77,13 +77,11 @@ class StudentServiceTest {
 
   @Test
   void 受講生詳細の登録＿入力した値が適切にオブジェクトに入ること() {
-    StudentDetail studentDetail = new StudentDetail();
     Student student = new Student();
-    studentDetail.setStudent(student);
     StudentCourse studentCourse = new StudentCourse();
-    List<StudentCourse> studentCourseList = new ArrayList<>();
-    studentCourseList.add(studentCourse);
-    studentDetail.setStudentCourseList(studentCourseList);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+
     doNothing().when(repository).registerStudent(student);
     doNothing().when(repository).registerStudentCourse(studentCourse);
 
@@ -96,13 +94,11 @@ class StudentServiceTest {
 
   @Test
   void 受講生詳細の更新＿入力した値で適切に更新が機能すること() {
-    StudentDetail studentDetail = new StudentDetail();
     Student student = new Student();
-    studentDetail.setStudent(student);
-    List<StudentCourse> studentCourseList = new ArrayList<>();
     StudentCourse studentCourse = new StudentCourse();
-    studentCourseList.add(studentCourse);
-    studentDetail.setStudentCourseList(studentCourseList);
+    List<StudentCourse> studentCourseList = List.of(studentCourse);
+    StudentDetail studentDetail = new StudentDetail(student, studentCourseList);
+
     doNothing().when(repository).updateStudent(student);
     doNothing().when(repository).updateStudentCourse(studentCourse);
 

--- a/src/test/java/raisetech/student_management/service/StudentServiceTest.java
+++ b/src/test/java/raisetech/student_management/service/StudentServiceTest.java
@@ -60,7 +60,7 @@ class StudentServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"1","2","3"})
+  @ValueSource(strings = {"999"})
   void 受講生詳細の検索＿リポジトリが適切に呼び出されていること(String id) {
     Student student = new Student();
     List<StudentCourse> studentCourse = new ArrayList<>();


### PR DESCRIPTION
### 実装の概要
JUnitを使用し、StudentControllerのテストを実装しています。

### 変更理由
StudentControllerのテストが未実装であったため。

### やったこと
StudentControllerTestの生成
Mokitoのインストール
controllerメソッドのファイル実装

### やらないこと
それ以外のテスト実装

### 動作確認
受講生詳細登録の実行テスト（/registerStudent）
<img width="2256" height="1504" alt="スクリーンショット (249)" src="https://github.com/user-attachments/assets/8c6c5265-7881-4caf-aadc-c685c4fa2791" />


受講生更新の実行テスト（/updateStudent）
<img width="2256" height="1504" alt="スクリーンショット (250)" src="https://github.com/user-attachments/assets/76ffb772-7966-4d57-a717-177f347855d7" />

### 課題
ObjectMapperを使用することで、自動でJson形式に変換できるようにしましたが、孫半面verifyのところで、そのままstudentDetailとするとエラーになってしまいました。調べてみると、オブジェクト→JSON→オブジェクトとした際に、最初と最後のオブジェクトが別ものと認識されてしまうことが原因のようで、条件を緩める形でテストを通すようにしています。

### 工夫したこと
前回のServiceのテストを実装した際に、値を事前に準備するのにかなり長いコードを書いていたが、それを短く書く方法を見つけたので実践してみました。まだまだ知らないことの方が圧倒的に多いので、どんどん学習を進めていきます。
